### PR TITLE
Introduce "acyclic" YG script

### DIFF
--- a/yield-generators/yg-acyclic.py
+++ b/yield-generators/yg-acyclic.py
@@ -1,0 +1,40 @@
+#! /usr/bin/env python
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+from builtins import * # noqa: F401
+from future.utils import iteritems
+
+from jmbase import jmprint
+from jmclient import YieldGeneratorBasic, ygmain
+
+# User settings
+txfee = 100
+cjfee_a = 500
+cjfee_r = '0.00002'
+ordertype = 'swreloffer'
+nickserv_password = ''
+minsize = 100000
+gaplimit = 6
+
+
+class YieldGeneratorAcyclic(YieldGeneratorBasic):
+    """A yield-generator bot that sends funds linearly through the
+    mixdepths, but not back from the "lowest" depth to the beginning.
+    Instead, it lets funds accumulate there, so that they can then be manually
+    sent elsewhere as needed."""
+
+    def __init__(self, wallet, offerconfig):
+        super(YieldGeneratorAcyclic, self).__init__(wallet, offerconfig)
+
+    def get_available_mixdepths(self):
+        balances = self.wallet.get_balance_by_mixdepth(verbose=False)
+        return {m: b for m, b in iteritems(balances)
+                     if m < self.wallet.mixdepth}
+
+
+if __name__ == "__main__":
+    ygmain(YieldGeneratorAcyclic, txfee=txfee,
+           cjfee_a=cjfee_a, cjfee_r=cjfee_r,
+           ordertype=ordertype, nickserv_password=nickserv_password,
+           minsize=minsize, gaplimit=gaplimit)
+    jmprint('done', "success")


### PR DESCRIPTION
This change modernises the existing `yg-randomizer.py` script (which was outdated), based on https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/406.  It also introduces a new custom YG script (`yg-acyclic.py`), which just sends the funds through the YG bot once but keeps them in the "lowest" mixdepth rather than cycling them back to the beginning.  See https://github.com/JoinMarket-Org/joinmarket-clientserver/issues/404 for a discussion of this.